### PR TITLE
docs: clarify license — non-commercial use only under AGPL (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.14.2
+
+- Clarify license: internal/commercial use requires commercial license (#5)
+
 ## v2026.03.14.1
 
 - 35 tools across 6 domains: Devices (9), DNS (8), ACL (5), Keys (4), Tailnet (4), Diagnostics (5) (#1)

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -20,7 +20,7 @@ You likely need a commercial license if:
 
 ## When You Do NOT Need a Commercial License
 
-- **Personal or internal use** — using the software as-is within your organization
+- **Personal or non-commercial use** — using the software for personal projects or non-commercial purposes
 - **Open-source projects** — integrating with other AGPL-3.0 or compatible open-source projects
 - **Unmodified use** — running the unmodified MCP server to manage your own Tailscale tailnet
 
@@ -35,10 +35,10 @@ Commercial licenses are priced based on scope and usage. Sponsoring the project 
 ## FAQ
 
 **Q: Can I use mcp-tailscale for free in my company?**
-A: Yes, as long as you comply with the AGPL-3.0 license terms (including making source code available if you modify it or offer it as a network service).
+A: Only if you fully comply with the AGPL-3.0 license terms, which requires making your complete source code available under AGPL-3.0. If your company uses mcp-tailscale internally for commercial operations and does not want to release its source code, a commercial license is required.
 
 **Q: Does the AGPL apply if I just run the MCP server internally?**
-A: Running the unmodified server internally for your own use does not trigger the AGPL network service clause. You do not need a commercial license for this use case.
+A: Running the server internally within a commercial organization requires either full AGPL-3.0 compliance (including releasing your source code) or a commercial license. The AGPL-3.0 free use is intended for personal and non-commercial purposes only.
 
 **Q: What if I build a product that includes mcp-tailscale?**
 A: If your product is proprietary (closed-source), you need a commercial license. If your product is also AGPL-3.0 licensed, you can use it under the open-source license.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See [docs/api-reference.md](docs/api-reference.md) for the Tailscale API v2 endp
 
 This project is dual-licensed:
 
-- **Open Source**: [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE) — free for open-source and internal use
+- **Open Source**: [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE) — free for open-source and non-commercial use
 - **Commercial**: Available for proprietary integrations — see [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)
 
 If you use mcp-tailscale in a proprietary product or SaaS offering, a commercial license is required. Support development by [sponsoring us on GitHub](https://github.com/sponsors/itunified-io).


### PR DESCRIPTION
## Summary
- Change 'free for open-source and internal use' → 'free for open-source and non-commercial use'
- Update COMMERCIAL_LICENSE.md FAQ to clarify commercial organizations need a commercial license

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)