### PR TITLE
Add docs/superpowers/ to .gitignore (ADR-0021)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Superpowers plugin working artifacts (ADR-0021)
+docs/superpowers/


### PR DESCRIPTION
## Summary
- Add `docs/superpowers/` to `.gitignore` per ADR-0021
- Clean up leftover plan files from Tier 2 implementation

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)