### PR TITLE
fix: use /acl/validate endpoint for acl_test (#17)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,7 +42,7 @@ Authentication: `Authorization: Bearer <api-key>` or OAuth client credentials
 | `tailscale_acl_set` | POST | `/tailnet/{tailnet}/acl` |
 | `tailscale_acl_preview` | POST | `/tailnet/{tailnet}/acl/preview` |
 | `tailscale_acl_validate` | POST | `/tailnet/{tailnet}/acl/validate` |
-| `tailscale_acl_test` | POST | `/tailnet/{tailnet}/acl/test` |
+| `tailscale_acl_test` | POST | `/tailnet/{tailnet}/acl/validate` (shared with acl_validate) |
 
 ## Auth Keys
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -133,14 +133,6 @@ export interface AclValidationResult {
   message: string;
 }
 
-export interface AclTestResult {
-  results: Array<{
-    user: string;
-    errors: string[];
-    passed: boolean;
-  }>;
-}
-
 // Key types
 export interface AuthKey {
   id: string;

--- a/src/tools/acl.ts
+++ b/src/tools/acl.ts
@@ -4,7 +4,6 @@ import type {
   AclPolicy,
   AclPreviewResult,
   AclValidationResult,
-  AclTestResult,
 } from "../client/types.js";
 
 // ---------------------------------------------------------------------------
@@ -142,7 +141,7 @@ export const aclToolDefinitions = [
   {
     name: "tailscale_acl_test",
     description:
-      "Run ACL tests defined in the policy's 'tests' field. Returns pass/fail results for each test case.",
+      "Run ACL tests defined in the policy's 'tests' field by validating the policy. Returns validation results including test pass/fail outcomes.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -207,8 +206,8 @@ export async function handleAclTool(
 
       case "tailscale_acl_test": {
         const parsed = AclTestSchema.parse(args);
-        const result = await client.post<AclTestResult>(
-          `/tailnet/${client.tailnet}/acl/test`,
+        const result = await client.post<AclValidationResult>(
+          `/tailnet/${client.tailnet}/acl/validate`,
           parsed.policy,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };

--- a/tests/tools/acl.test.ts
+++ b/tests/tools/acl.test.ts
@@ -178,23 +178,21 @@ describe("handleAclTool", () => {
   });
 
   describe("tailscale_acl_test", () => {
-    it("runs ACL tests", async () => {
-      const mockTestResult = {
-        results: [{ user: "user@example.com", errors: [], passed: true }],
-      };
+    it("runs ACL tests via validate endpoint", async () => {
+      const mockValidationResult = { message: "" };
       const policyWithTests = {
         ...SAMPLE_POLICY,
         tests: [{ src: "user@example.com", accept: ["100.64.0.2:80"] }],
       };
-      const client = mockClient({ post: vi.fn().mockResolvedValue(mockTestResult) });
+      const client = mockClient({ post: vi.fn().mockResolvedValue(mockValidationResult) });
 
       const result = await handleAclTool("tailscale_acl_test", {
         policy: policyWithTests,
       }, client);
 
-      expect(result.content[0].text).toContain("passed");
+      expect(result.content[0].text).toContain("message");
       expect(client.post).toHaveBeenCalledWith(
-        `/tailnet/${TAILNET}/acl/test`,
+        `/tailnet/${TAILNET}/acl/validate`,
         policyWithTests,
       );
     });


### PR DESCRIPTION
## Summary
- Changed `acl_test` to use `/acl/validate` endpoint instead of nonexistent `/acl/test`
- Tailscale API v2 has no dedicated `/acl/test` endpoint — tests run during validation
- Removed unused `AclTestResult` type, updated unit tests and API reference

Closes #17

## Test plan
- [x] `npm test` — 188 tests pass
- [x] `npm run build` — TypeScript compiles cleanly
- [ ] `/ts-test` — verify `acl_test` no longer returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)