### PR TITLE
fix: remove unsupported generic webhook provider (#18)

### DIFF
--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -24,7 +24,7 @@ const WEBHOOK_EVENT_TYPES = [
   "exitNodeIPForwardingNotEnabled",
 ] as const;
 
-const PROVIDER_TYPES = ["slack", "mattermost", "googlechat", "discord", "generic"] as const;
+const PROVIDER_TYPES = ["slack", "mattermost", "googlechat", "discord"] as const;
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -34,7 +34,7 @@ const WebhookListSchema = z.object({});
 
 const WebhookCreateSchema = z.object({
   endpointUrl: z.string().url("Must be a valid URL"),
-  providerType: z.enum(PROVIDER_TYPES).optional().default("generic"),
+  providerType: z.enum(PROVIDER_TYPES).optional(),
   subscriptions: z
     .array(z.enum(WEBHOOK_EVENT_TYPES))
     .min(1, "At least one subscription event type is required"),
@@ -78,8 +78,8 @@ export const webhookToolDefinitions = [
         },
         providerType: {
           type: "string",
-          enum: ["slack", "mattermost", "googlechat", "discord", "generic"],
-          description: "The webhook provider type (default: generic)",
+          enum: ["slack", "mattermost", "googlechat", "discord"],
+          description: "The webhook provider type (optional, omit for default Tailscale format)",
         },
         subscriptions: {
           type: "array",
@@ -156,13 +156,14 @@ export async function handleWebhookTool(
 
       case "tailscale_webhook_create": {
         const parsed = WebhookCreateSchema.parse(args);
+        const body: Record<string, unknown> = {
+          endpointUrl: parsed.endpointUrl,
+          subscriptions: parsed.subscriptions,
+        };
+        if (parsed.providerType) body.providerType = parsed.providerType;
         const result = await client.post<TailscaleWebhook>(
           `/tailnet/${client.tailnet}/webhooks`,
-          {
-            endpointUrl: parsed.endpointUrl,
-            providerType: parsed.providerType,
-            subscriptions: parsed.subscriptions,
-          },
+          body,
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }

--- a/tests/tools/webhooks.test.ts
+++ b/tests/tools/webhooks.test.ts
@@ -60,7 +60,7 @@ describe("handleWebhookTool", () => {
           {
             endpointId: "wh_123",
             endpointUrl: "https://hooks.example.com/tailscale",
-            providerType: "generic",
+            providerType: "slack",
             subscriptions: ["nodeCreated", "nodeDeleted"],
           },
         ],
@@ -110,7 +110,7 @@ describe("handleWebhookTool", () => {
       );
     });
 
-    it("defaults providerType to generic", async () => {
+    it("omits providerType when not specified", async () => {
       const client = mockClient({ post: vi.fn().mockResolvedValue({}) });
 
       await handleWebhookTool("tailscale_webhook_create", {
@@ -118,10 +118,8 @@ describe("handleWebhookTool", () => {
         subscriptions: ["policyUpdate"],
       }, client);
 
-      expect(client.post).toHaveBeenCalledWith(
-        `/tailnet/${TAILNET}/webhooks`,
-        expect.objectContaining({ providerType: "generic" }),
-      );
+      const callArgs = (client.post as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1]).not.toHaveProperty("providerType");
     });
 
     it("requires endpointUrl", async () => {
@@ -184,7 +182,7 @@ describe("handleWebhookTool", () => {
       const mockWebhook = {
         endpointId: "wh_789",
         endpointUrl: "https://hooks.example.com/tailscale",
-        providerType: "generic",
+        providerType: "slack",
       };
       const client = mockClient({ get: vi.fn().mockResolvedValue(mockWebhook) });
 


### PR DESCRIPTION
## Summary
- Removed `"generic"` from `PROVIDER_TYPES` — not a valid Tailscale API value
- Made `providerType` optional with no default (Tailscale uses its own default when omitted)
- Handler conditionally includes `providerType` in POST body only when explicitly set
- Updated unit tests to verify omission behavior

Closes #18

## Test plan
- [x] `npm test` — 188 tests pass
- [x] `npm run build` — TypeScript compiles cleanly
- [ ] `/ts-test` — verify webhook tools work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)