### PR TITLE
docs: add product positioning docs (#29)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,220 @@
+# Architecture
+
+This document describes the architecture of mcp-tailscale — from the current single-runtime design to the target multi-component architecture.
+
+## Current Architecture
+
+mcp-tailscale is a single-process MCP server that translates MCP tool calls into Tailscale API v2 requests.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        MCP Client                               │
+│              (Claude Code, AI Agent, Custom)                    │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │ MCP Protocol (stdio or SSE)
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    mcp-tailscale Runtime                         │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────────────────┐  │
+│  │Transport │  │  Tool    │  │     Tailscale Client         │  │
+│  │ stdio/SSE│──│ Registry │──│  (API Key or OAuth)          │  │
+│  │  + Auth  │  │ 48 tools │  │  Bearer token, auto-refresh  │  │
+│  └──────────┘  └──────────┘  └──────────────┬───────────────┘  │
+│                                              │                  │
+│  ┌──────────┐  ┌──────────┐                  │                  │
+│  │Validation│  │  Error   │                  │                  │
+│  │   (Zod)  │  │ Handling │                  │                  │
+│  └──────────┘  └──────────┘                  │                  │
+└──────────────────────────────────────────────┼──────────────────┘
+                                               │ HTTPS
+                                               ▼
+                                ┌──────────────────────────┐
+                                │   Tailscale API v2       │
+                                │ api.tailscale.com        │
+                                └──────────────┬───────────┘
+                                               │
+                                               ▼
+                                ┌──────────────────────────┐
+                                │   Your Tailnet           │
+                                │  Devices, DNS, ACL, ...  │
+                                └──────────────────────────┘
+```
+
+### Components
+
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| Transport | `src/index.ts`, `src/transport.ts` | stdio/SSE transport, Bearer auth middleware |
+| Tool Registry | `src/tools/*.ts` | 48 tools across 9 domains, Zod input schemas |
+| Tailscale Client | `src/client/tailscale-client.ts` | HTTP client, API key Bearer auth |
+| OAuth Client | `src/client/tailscale-oauth-client.ts` | OAuth credentials, token auto-refresh |
+| Client Factory | `src/client/client-factory.ts` | Selects auth method (OAuth > API key) |
+| Validation | `src/utils/validation.ts` | Shared Zod schemas (device IDs, CIDR, domains) |
+| Error Handling | `src/utils/errors.ts` | TailscaleApiError, credential-safe messages |
+| Types | `src/client/types.ts` | API response types, ITailscaleClient interface |
+
+### Data Flow
+
+```
+1. MCP Client sends tool call (e.g., tailscale_device_list)
+2. Transport layer receives and routes to tool handler
+3. Zod schema validates input parameters
+4. Tool handler calls TailscaleClient method
+5. Client adds Bearer token, sends HTTPS request to api.tailscale.com
+6. API response is typed and returned as JSON text content
+7. On error: TailscaleApiError extracts message without leaking credentials
+```
+
+## Target Architecture
+
+As mcp-tailscale evolves from a single runtime into a product platform, the architecture separates into three distinct layers:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        MCP Clients                              │
+│         Claude Code  ·  AI Agents  ·  Custom Apps               │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │ MCP Protocol
+                           ▼
+┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┐
+│                    Cloud Layer (Future)                         │
+│                                                                 │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │  Admin       │  │   Fleet      │  │    Observability     │  │
+│  │  Console     │  │   Manager    │  │    (Logs, Metrics)   │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+│                                                                 │
+ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┬ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+                           │
+┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┐
+│                Enterprise Layer                                 │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐   │
+│  │   RBAC   │  │   SSO    │  │  Audit   │  │   Policy     │   │
+│  │          │  │OIDC/SAML │  │  Events  │  │   Engine     │   │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────────┘   │
+│                                                                 │
+ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┬ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+                           │
+┌──────────────────────────┼──────────────────────────────────────┐
+│                    Core Runtime (OSS)                            │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────────────────┐  │
+│  │Transport │  │  Tool    │  │     API Clients              │  │
+│  │ stdio/SSE│  │ Registry │  │  Tailscale · (Extensible)    │  │
+│  └──────────┘  └──────────┘  └──────────────────────────────┘  │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────────────────────┐  │
+│  │Validation│  │  Error   │  │     Plugin / Connector SDK   │  │
+│  │   (Zod)  │  │ Handling │  │  (Future)                    │  │
+│  └──────────┘  └──────────┘  └──────────────────────────────┘  │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │ HTTPS
+                           ▼
+                ┌──────────────────────────┐
+                │   Infrastructure APIs    │
+                │  Tailscale · (Others)    │
+                └──────────────────────────┘
+```
+
+### Layer Responsibilities
+
+| Layer | Scope | Repository | License |
+|-------|-------|------------|---------|
+| **Core Runtime** | Execution — MCP protocol, tool registry, API clients, validation | `mcp-tailscale` (public) | AGPL-3.0 |
+| **Enterprise** | Governance — RBAC, SSO, audit, policy engine, multi-tenancy | Private (future) | Commercial |
+| **Cloud** | Operations — Hosted control plane, fleet management, observability | Private (future) | Commercial SaaS |
+
+### Boundary Definitions
+
+**Core Runtime** is the execution engine. It handles:
+- MCP protocol negotiation (stdio/SSE)
+- Tool discovery and invocation
+- Input validation and error handling
+- API client authentication and requests
+- Plugin/connector lifecycle (future)
+
+**Enterprise Layer** wraps the Core Runtime with governance:
+- Who can use which tools (RBAC)
+- How users authenticate (SSO)
+- What happened and when (Audit)
+- What is allowed and what is not (Policy)
+- Isolation between teams (Multi-tenancy)
+
+**Cloud Layer** manages fleets of Enterprise instances:
+- Deployment and scaling of gateway instances
+- Centralized monitoring and alerting
+- Configuration management across instances
+- Usage tracking and billing
+
+### Security Model
+
+```
+MCP Client
+    │
+    ▼
+Transport Auth ──── Bearer token (SSE) or process isolation (stdio)
+    │
+    ▼
+[Enterprise: RBAC] ── Role check: does this identity have access to this tool?
+    │
+    ▼
+[Enterprise: Policy] ── Policy check: is this operation allowed right now?
+    │
+    ▼
+Tool Execution ──── Zod validates input, tool handler runs
+    │
+    ▼
+[Enterprise: Audit] ── Log: who, what, when, result
+    │
+    ▼
+API Client Auth ──── Bearer token (API key) or OAuth (auto-refresh)
+    │
+    ▼
+Tailscale API ──── HTTPS to api.tailscale.com
+```
+
+Items in `[brackets]` are enterprise layer additions — the Core Runtime operates without them.
+
+## Technology Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Runtime | Node.js ≥ 20 | Native ES modules, broad MCP SDK support |
+| Language | TypeScript (strict) | Type safety, IDE support, refactoring confidence |
+| Validation | Zod | Runtime + compile-time validation, composable schemas |
+| HTTP Client | Axios | Interceptors for auth, timeout, error handling |
+| Transport | stdio + SSE (Express) | stdio for local, SSE for remote/multi-client |
+| Testing | Vitest | Fast, TypeScript-native, ESM support |
+| Auth | API key + OAuth | API key for humans, OAuth for services |
+
+## File Structure
+
+```
+src/
+  index.ts                    # Entry point — server setup, tool registration
+  transport.ts                # Transport config + SSE auth middleware
+  client/
+    tailscale-client.ts       # API key HTTP client
+    tailscale-oauth-client.ts # OAuth client (auto-refresh)
+    client-factory.ts         # Auth method selection
+    types.ts                  # API types + ITailscaleClient interface
+  tools/
+    devices.ts                # 11 device management tools
+    dns.ts                    # 8 DNS tools
+    acl.ts                    # 5 ACL tools
+    keys.ts                   # 4 auth key tools
+    tailnet.ts                # 5 tailnet tools
+    users.ts                  # 2 user tools
+    webhooks.ts               # 4 webhook tools
+    posture.ts                # 4 posture integration tools
+    diagnostics.ts            # 5 diagnostics tools
+  utils/
+    validation.ts             # Shared Zod schemas
+    errors.ts                 # Error extraction, TailscaleApiError
+tests/                        # Vitest unit tests (mocked API)
+docs/
+  plans/                      # Design documents
+  api-reference.md            # Tailscale API v2 endpoint mapping
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.15.4
+
+- Add product positioning docs: restructured README, ROADMAP.md, ARCHITECTURE.md, PRODUCT_PACKAGING.md (#29)
+
 ## v2026.03.15.3
 
 - Switch Glama badge from score to card format (#11)

--- a/PRODUCT_PACKAGING.md
+++ b/PRODUCT_PACKAGING.md
@@ -1,0 +1,138 @@
+# Product Packaging
+
+This document defines the product tiers for mcp-tailscale. The tiers represent a clear progression from self-hosted open source to managed cloud, with honest boundaries — no artificial limitations on the free tier.
+
+## Tier Overview
+
+| Tier | Target | Distribution | License |
+|------|--------|-------------|---------|
+| **Community** | Developers, small teams | Public GitHub, self-hosted | AGPL-3.0 |
+| **Team** | Engineering teams, startups | Private distribution | Commercial |
+| **Enterprise** | Large organizations, regulated industries | Private distribution | Commercial |
+| **Cloud** | Any organization (managed) | Hosted SaaS | Commercial SaaS |
+
+## Feature Matrix
+
+| Feature | Community | Team | Enterprise | Cloud |
+|---------|:---------:|:----:|:----------:|:-----:|
+| **Runtime** | | | | |
+| 48 tools across 9 domains | ✅ | ✅ | ✅ | ✅ |
+| Tailscale API v2 full coverage | ✅ | ✅ | ✅ | ✅ |
+| stdio transport | ✅ | ✅ | ✅ | ✅ |
+| SSE transport with Bearer auth | ✅ | ✅ | ✅ | ✅ |
+| API key authentication | ✅ | ✅ | ✅ | ✅ |
+| OAuth client credentials | ✅ | ✅ | ✅ | ✅ |
+| Zod input validation | ✅ | ✅ | ✅ | ✅ |
+| Plugin/Connector SDK | ✅ | ✅ | ✅ | ✅ |
+| Claude Code skills | ✅ | ✅ | ✅ | ✅ |
+| Docker image | ✅ | ✅ | ✅ | ✅ |
+| **Identity & Access** | | | | |
+| Role-based access control (RBAC) | — | ✅ | ✅ | ✅ |
+| OIDC single sign-on | — | ✅ | ✅ | ✅ |
+| SAML single sign-on | — | — | ✅ | ✅ |
+| Team management | — | ✅ | ✅ | ✅ |
+| **Governance** | | | | |
+| Audit event logging | — | ✅ | ✅ | ✅ |
+| Policy engine (tool access rules) | — | — | ✅ | ✅ |
+| Approval workflows | — | — | ✅ | ✅ |
+| Compliance reporting | — | — | ✅ | ✅ |
+| **Multi-Tenancy** | | | | |
+| Tenant isolation | — | — | ✅ | ✅ |
+| Per-tenant configuration | — | — | ✅ | ✅ |
+| Cross-tenant admin | — | — | ✅ | ✅ |
+| **Operations** | | | | |
+| Self-hosted deployment | ✅ | ✅ | ✅ | — |
+| Hosted control plane | — | — | — | ✅ |
+| Gateway fleet management | — | — | — | ✅ |
+| Centralized observability | — | — | — | ✅ |
+| Auto-updates | — | — | — | ✅ |
+| **Support** | | | | |
+| Community (GitHub Issues) | ✅ | ✅ | ✅ | ✅ |
+| Priority support | — | ✅ | ✅ | ✅ |
+| SLA | — | — | ✅ | ✅ |
+| Dedicated support channel | — | — | ✅ | ✅ |
+| **License** | | | | |
+| AGPL-3.0 (open source) | ✅ | — | — | — |
+| Commercial license | — | ✅ | ✅ | ✅ |
+
+## Tier Details
+
+### Community (Free, AGPL-3.0)
+
+The complete MCP Gateway Runtime — no artificial feature limitations. Self-host, contribute, build on it.
+
+**Who it's for:** Individual developers, open-source projects, small teams evaluating mcp-tailscale.
+
+**What you get:**
+- Full Tailscale API v2 coverage (48 tools, 9 domains)
+- All transports (stdio, SSE)
+- All authentication methods (API key, OAuth)
+- Plugin/Connector SDK (when available)
+- Claude Code skills
+- Docker image
+- Community support via GitHub Issues
+
+**License obligation:** AGPL-3.0 — if you modify the software or use it in a network service, you must release your source code under AGPL-3.0.
+
+### Team (Commercial)
+
+Adds identity, access control, and audit capabilities for engineering teams.
+
+**Who it's for:** Startups and engineering teams that need to control who can access infrastructure tools through AI agents.
+
+**What you get:**
+- Everything in Community
+- RBAC — define roles and permissions for tool access
+- OIDC SSO — integrate with your identity provider
+- Audit logging — structured records of every tool invocation
+- Team management — invite, manage, remove team members
+- Commercial license — no AGPL source code obligations
+- Priority support
+
+### Enterprise (Commercial)
+
+Full governance suite for organizations with compliance requirements and multi-team structures.
+
+**Who it's for:** Large organizations, regulated industries, multi-team environments.
+
+**What you get:**
+- Everything in Team
+- SAML SSO — enterprise identity federation
+- Policy engine — declarative rules for tool access, rate limiting, approval workflows
+- Multi-tenant isolation — separate configuration and execution per team/org
+- Compliance reporting — exportable audit trails
+- SLA and dedicated support channel
+
+### Cloud (Future — Commercial SaaS)
+
+Managed cloud offering — zero self-hosting, zero maintenance.
+
+**Who it's for:** Organizations that want managed infrastructure access without running their own gateway.
+
+**What you get:**
+- Everything in Enterprise
+- Hosted control plane — we run the gateway, you connect your tailnet
+- Fleet management — deploy and manage multiple gateway instances
+- Centralized observability — logs, metrics, alerting in one dashboard
+- Auto-updates — always on the latest version
+- Usage-based billing
+
+## Pricing
+
+Pricing is not yet published. Contact us to discuss:
+
+- **GitHub Sponsors**: [github.com/sponsors/itunified-io](https://github.com/sponsors/itunified-io)
+
+## FAQ
+
+**Q: Will the Community edition ever be limited to push people toward paid tiers?**
+A: No. The Community edition is the full runtime. Enterprise features (RBAC, SSO, audit, policy) are genuinely new capabilities that don't exist in the current codebase — they are not features removed from the free tier.
+
+**Q: Can I use the Community edition commercially?**
+A: Yes, if you comply with AGPL-3.0 terms (including releasing your source code). If you cannot or prefer not to comply with AGPL-3.0, you need a commercial license.
+
+**Q: When will Team/Enterprise be available?**
+A: See [ROADMAP.md](ROADMAP.md) for the development timeline. Phase 2 (Enterprise) follows Phase 1 (OSS Adoption).
+
+**Q: Is the Cloud tier available?**
+A: Not yet. The Cloud tier will only be built when Phase 2 adoption demonstrates demand. See [ROADMAP.md](ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-tailscale
 
+**Secure MCP access for private infrastructure over Tailscale**
+
 [![GitHub release](https://img.shields.io/github/v/release/itunified-io/mcp-tailscale?style=flat-square)](https://github.com/itunified-io/mcp-tailscale/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CalVer](https://img.shields.io/badge/calver-YYYY.0M.DD.MICRO-22bfae?style=flat-square)](https://calver.org)
@@ -7,37 +9,25 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square)](https://www.typescriptlang.org/)
 [![mcp-tailscale MCP server](https://glama.ai/mcp/servers/itunified-io/mcp-tailscale/badges/card.svg)](https://glama.ai/mcp/servers/itunified-io/mcp-tailscale)
 
-Slim Tailscale MCP Server for managing devices, DNS/Split DNS, ACL policies, auth keys, users, webhooks, and tailnet settings via Tailscale API v2.
+## The Problem
+
+AI agents need access to internal tools, services, and infrastructure — but exposing private systems to the internet creates unacceptable security risks. VPNs are complex, SSH tunnels are fragile, and API gateways add latency and maintenance overhead.
+
+**mcp-tailscale** bridges this gap: a lightweight MCP server that gives AI agents secure, authenticated access to your Tailscale-connected infrastructure — without exposing anything to the public internet.
+
+## What It Does
+
+mcp-tailscale is an MCP Gateway Runtime that connects AI agents (Claude, GPT, custom) to your private infrastructure through Tailscale's zero-trust network. It provides **48 tools across 9 domains** for managing devices, DNS, ACL policies, auth keys, users, webhooks, posture integrations, and tailnet settings — all through the Tailscale API v2.
 
 **No SSH. No shell execution. API-only. 4 runtime dependencies.**
 
-## Table of Contents
+## Use Cases
 
-- [Features](#features)
-- [Quick Start](#quick-start)
-- [Claude Code Integration](#claude-code-integration)
-- [Skills](#skills)
-- [SSE Transport](#sse-transport)
-- [Configuration](#configuration)
-- [Tools](#tools)
-- [Development](#development)
-- [License](#license)
-
-## Features
-
-48 tools across 9 domains:
-
-- **Devices** — List, get, delete, authorize, expire, rename devices; manage routes, tags, and posture attributes
-- **DNS** — Global nameservers, search paths, split DNS configuration, MagicDNS preferences
-- **ACL** — Get, set, preview, validate, and test ACL policies
-- **Keys** — List, get, create, and revoke auth keys
-- **Tailnet** — Settings (read/write), contacts, Tailnet Lock status
-- **Users** — List and get tailnet users with role/type filtering
-- **Webhooks** — Create, list, get, and delete webhook endpoints
-- **Posture Integrations** — List, get, create, and delete third-party posture provider integrations
-- **Diagnostics** — Tailnet status summary, API connectivity check, log streaming, DERP map
-
-**Authentication:** API key or OAuth client credentials (auto-refresh)
+- **DevOps Automation** — Let AI agents manage device authorization, subnet routes, and ACL policies across your tailnet
+- **DNS Management** — Configure split DNS, global nameservers, and MagicDNS through natural language
+- **Security Auditing** — Automated ACL policy validation, posture compliance checks, and key rotation
+- **Fleet Management** — Monitor device status, manage tags, and onboard new devices at scale
+- **Infrastructure as Conversation** — Query and modify your private network configuration through AI-driven workflows
 
 ## Quick Start
 
@@ -67,6 +57,22 @@ Add to `.mcp.json` in your project root:
   }
 }
 ```
+
+## Features
+
+48 tools across 9 domains:
+
+- **Devices** — List, get, delete, authorize, expire, rename devices; manage routes, tags, and posture attributes
+- **DNS** — Global nameservers, search paths, split DNS configuration, MagicDNS preferences
+- **ACL** — Get, set, preview, validate, and test ACL policies
+- **Keys** — List, get, create, and revoke auth keys
+- **Tailnet** — Settings (read/write), contacts, Tailnet Lock status
+- **Users** — List and get tailnet users with role/type filtering
+- **Webhooks** — Create, list, get, and delete webhook endpoints
+- **Posture Integrations** — List, get, create, and delete third-party posture provider integrations
+- **Diagnostics** — Tailnet status summary, API connectivity check, log streaming, DERP map
+
+**Authentication:** API key or OAuth client credentials (auto-refresh)
 
 ## Skills
 
@@ -210,6 +216,14 @@ All requests require `Authorization: Bearer <token>`. The server will not start 
 | `tailscale_log_stream_set` | Set log streaming configuration (requires `confirm: true`) |
 | `tailscale_derp_map` | Get DERP relay map |
 
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed architecture diagrams and component descriptions.
+
+## Roadmap
+
+See [ROADMAP.md](ROADMAP.md) for the product development roadmap.
+
 ## Development
 
 ```bash
@@ -220,6 +234,37 @@ npm run typecheck  # Type check only (no emit)
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 See [docs/api-reference.md](docs/api-reference.md) for the Tailscale API v2 endpoint mapping.
+
+## Open Source
+
+mcp-tailscale is the community edition — a fully functional MCP Gateway Runtime under AGPL-3.0. Self-host it, contribute to it, build on it.
+
+What you get with the open-source edition:
+
+- Complete Tailscale API v2 coverage (48 tools, 9 domains)
+- stdio and SSE transport
+- API key and OAuth authentication
+- Zod-validated inputs, structured error handling
+- Claude Code skills for common workflows
+- Full test suite (vitest)
+
+## Commercial
+
+For organizations that need governance, compliance, and multi-tenant capabilities on top of the open-source runtime, we offer commercial editions with enterprise features.
+
+**Planned enterprise capabilities:**
+
+- Role-based access control (RBAC)
+- OIDC/SAML single sign-on
+- Audit event logging
+- Policy engine for tool access control
+- Multi-tenant isolation
+- Commercial license (no AGPL obligations)
+- Priority support and SLA
+
+See [PRODUCT_PACKAGING.md](PRODUCT_PACKAGING.md) for tier details.
+
+Contact us: [GitHub Sponsors](https://github.com/sponsors/itunified-io)
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,67 @@
+# Roadmap
+
+This roadmap outlines the product development phases for mcp-tailscale. Phases are sequential — each builds on the previous one. Timelines are directional, not commitments.
+
+## Phase 1: OSS Adoption (Current)
+
+Establish mcp-tailscale as the most complete, best-documented open-source MCP server for Tailscale.
+
+### Delivered
+
+- [x] 48 tools across 9 domains (Devices, DNS, ACL, Keys, Tailnet, Users, Webhooks, Posture, Diagnostics)
+- [x] Tailscale API v2 full coverage
+- [x] API key and OAuth client credentials authentication
+- [x] stdio and SSE transport with Bearer token auth
+- [x] Zod-validated inputs on all tools
+- [x] Structured error handling (TailscaleApiError)
+- [x] 188 unit tests (vitest)
+- [x] 7 Claude Code skills for common workflows
+- [x] Dual licensing (AGPL-3.0 + Commercial)
+- [x] Glama registry listing with quality badges
+
+### Planned
+
+- [ ] Docker image for easy self-hosting
+- [ ] Connector/plugin SDK for extending the runtime with custom tools
+- [ ] Example connectors (HTTP proxy, filesystem, Kubernetes)
+- [ ] Self-hosting documentation and deployment guides
+- [ ] npm package publishing
+- [ ] Official MCP Registry listing
+
+## Phase 2: Enterprise Boundary
+
+Add governance, compliance, and multi-tenant capabilities for organizations that need control over AI agent access to infrastructure.
+
+### Planned
+
+- [ ] Role-based access control (RBAC) — define who can use which tools
+- [ ] OIDC/SAML single sign-on — integrate with existing identity providers
+- [ ] Audit event system — structured logs of every tool invocation with context
+- [ ] Policy engine — declarative rules for tool access, rate limiting, and approval workflows
+- [ ] Admin API — programmatic management of users, roles, and policies
+- [ ] Multi-tenant runtime — isolated tool execution per team or organization
+- [ ] Commercial license distribution
+
+## Phase 3: Cloud (When Demand Is Proven)
+
+Managed cloud offering — only when there is demonstrated demand from Phase 2 customers.
+
+### Planned
+
+- [ ] Hosted Control Plane — managed gateway runtime with zero self-hosting
+- [ ] Gateway fleet management — deploy, monitor, and update gateway instances
+- [ ] Hosted observability — centralized logging, metrics, and alerting
+- [ ] Admin console — web UI for managing gateways, users, and policies
+- [ ] Usage metering — consumption-based billing
+
+## How We Decide What to Build
+
+- **Phase 1** items are driven by community feedback and Tailscale API coverage gaps
+- **Phase 2** items are driven by enterprise customer conversations and compliance requirements
+- **Phase 3** items are only built when Phase 2 adoption demonstrates clear demand for managed hosting
+
+## Contributing
+
+Phase 1 features are open to community contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved.
+
+For enterprise feature discussions, contact us via [GitHub Sponsors](https://github.com/sponsors/itunified-io).


### PR DESCRIPTION
## Summary

- Restructure README.md from technical tool listing to product-oriented documentation (problem → solution → use cases → commercial)
- Add ROADMAP.md with 3-phase development plan (OSS Adoption → Enterprise → Cloud)
- Add ARCHITECTURE.md with ASCII diagrams for current and target architecture (Core → Enterprise → Cloud layers)
- Add PRODUCT_PACKAGING.md with feature matrix across Community/Team/Enterprise/Cloud tiers

Closes #29

## Test plan

- [ ] Verify all links in README resolve correctly
- [ ] Verify no real credentials, hostnames, or internal topology in any document (ADR-0004)
- [ ] Verify ASCII diagrams render correctly on GitHub
- [ ] Verify feature matrix table renders correctly
- [ ] Build succeeds (`npm run build`)
- [ ] Tests pass (`npm test`)
- [ ] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)