### PR TITLE
chore: add FUNDING.yml for Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [itunified-io]


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` linking to `github.com/sponsors/itunified-io`
- Enables the "Sponsor" button on the repo page

## Test plan

- [ ] Verify Sponsor button appears on repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)