### PR TITLE
feat: publish to npm and prepare for MCP registry (#12)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# Source (compiled output in dist/ is included)
+src/
+tests/
+docs/
+
+# Config
+tsconfig.json
+.env
+.env.*
+!.env.example
+.claude/
+.github/
+
+# Dev files
+*.tsbuildinfo
+.eslintcache
+coverage/
+.nyc_output/
+*.tgz
+
+# Superpowers
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.15.5
+
+- Publish to npm as `@itunified/mcp-tailscale`, add `.npmignore`, `bin` entry, expanded keywords (#12)
+- Update package.json version to `2026.3.15`, description aligned with product positioning
+
 ## v2026.03.15.4
 
 - Add product positioning docs: restructured README, ROADMAP.md, ARCHITECTURE.md, PRODUCT_PACKAGING.md (#29)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@itunified/mcp-tailscale",
-  "version": "2026.3.14",
-  "description": "Slim Tailscale MCP Server — Devices, DNS/Split DNS, ACL, Keys, Tailnet management via Tailscale API v2",
+  "version": "2026.3.15",
+  "description": "Secure MCP access for private infrastructure over Tailscale — 48 tools for devices, DNS, ACL, keys, users, webhooks, posture, and tailnet management via Tailscale API v2",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "mcp-tailscale": "dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
@@ -15,13 +18,23 @@
     "type": "git",
     "url": "https://github.com/itunified-io/mcp-tailscale.git"
   },
+  "homepage": "https://github.com/itunified-io/mcp-tailscale",
+  "bugs": {
+    "url": "https://github.com/itunified-io/mcp-tailscale/issues"
+  },
   "keywords": [
     "mcp",
+    "mcp-server",
+    "model-context-protocol",
     "tailscale",
+    "tailnet",
+    "vpn",
     "dns",
     "split-dns",
-    "tailnet",
-    "vpn"
+    "acl",
+    "zero-trust",
+    "infrastructure",
+    "ai-agent"
   ],
   "author": "itunified-io",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary

- Add `.npmignore` to control npm package contents (exclude src, tests, docs)
- Add `bin` entry for `mcp-tailscale` CLI command
- Expand keywords for npm discoverability (mcp-server, model-context-protocol, zero-trust, ai-agent)
- Add `homepage` and `bugs` URLs
- Update description to match product positioning
- Bump version to `2026.3.15`

Closes #12

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm test` — 188 tests pass
- [ ] `npm pack --dry-run` shows correct contents (dist/ included, src/tests excluded)
- [ ] `npm publish --access public` succeeds
- [ ] Package visible at npmjs.com/package/@itunified/mcp-tailscale
- [ ] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)