### PR TITLE
feat: publish to npm as tailscale-mcp (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 ## v2026.03.15.5
 
-- Publish to npm as `@itunified/mcp-tailscale`, add `.npmignore`, `bin` entry, expanded keywords (#12)
+- Publish to npm as `tailscale-mcp`, add `.npmignore`, `bin` entry, expanded keywords (#12)
+- Rename package from `@itunified/mcp-tailscale` to `tailscale-mcp` (npm free org cannot publish public scoped packages)
 - Update package.json version to `2026.3.15`, description aligned with product positioning
 
 ## v2026.03.15.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,14 @@ docs/
 4. Push tag: `git push origin --tags`
 5. Create GitHub release: `gh release create v2026.03.13.1 --title "v2026.03.13.1 — <title>" --notes "<release notes>"`
 6. Release notes must list what changed and reference closed issues
+7. **Publish to npm**: `npm run build && npm publish --access public` (package: `tailscale-mcp`)
+
+### npm Publishing — MANDATORY
+- npm package name: `tailscale-mcp` (unscoped, published to npmjs.com)
+- **Every release MUST be published to npm** after tagging
+- Ensure `npm run build` succeeds before publishing
+- Verify with `npm view tailscale-mcp version` after publishing
+- Auth: granular access token set via `npm config set //registry.npmjs.org/:_authToken TOKEN`
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Secure MCP access for private infrastructure over Tailscale**
 
+[![npm](https://img.shields.io/npm/v/tailscale-mcp?style=flat-square)](https://www.npmjs.com/package/tailscale-mcp)
 [![GitHub release](https://img.shields.io/github/v/release/itunified-io/mcp-tailscale?style=flat-square)](https://github.com/itunified-io/mcp-tailscale/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
 [![CalVer](https://img.shields.io/badge/calver-YYYY.0M.DD.MICRO-22bfae?style=flat-square)](https://calver.org)
@@ -31,7 +32,17 @@ mcp-tailscale is an MCP Gateway Runtime that connects AI agents (Claude, GPT, cu
 
 ## Quick Start
 
+### Install from npm
+
 ```bash
+npm install -g tailscale-mcp
+```
+
+### Or clone and build from source
+
+```bash
+git clone https://github.com/itunified-io/mcp-tailscale.git
+cd mcp-tailscale
 npm install
 cp .env.example .env   # Edit with your Tailscale API key and tailnet name
 npm run build

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@itunified/mcp-tailscale",
+  "name": "tailscale-mcp",
   "version": "2026.3.15",
   "description": "Secure MCP access for private infrastructure over Tailscale — 48 tools for devices, DNS, ACL, keys, users, webhooks, posture, and tailnet management via Tailscale API v2",
   "type": "module",


### PR DESCRIPTION
## Summary

- Publish to npm as `tailscale-mcp` (unscoped — `@itunified` free org cannot publish public scoped packages)
- Add `.npmignore` to control published contents
- Add `bin` entry for `mcp-tailscale` CLI command
- Add npm badge to README, npm install to Quick Start
- Expand keywords for npm discoverability
- Update CLAUDE.md: npm publishing is MANDATORY on every release

Closes #12

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm test` — 188 tests pass
- [ ] Package live at npmjs.com/package/tailscale-mcp
- [ ] `npm view tailscale-mcp version` returns `2026.3.15`
- [ ] CHANGELOG updated
- [ ] CLAUDE.md updated with npm publishing workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)