### PR TITLE
feat: register on MCP registry and npm publish (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ vite.config.ts.timestamp-*
 
 # Superpowers plugin working artifacts (ADR-0021)
 docs/superpowers/
+
+# MCP Registry tokens
+.mcpregistry_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.1
+
+- Register on official MCP Registry as `io.github.itunified-io/tailscale` (#12)
+- Add `server.json` metadata for MCP registry publishing
+- Add `mcpName` field to package.json for registry validation
+- Bump version to `2026.3.16`, publish `tailscale-mcp@2026.3.16` to npm
+- Add `.mcpregistry_*` to `.gitignore`
+
 ## v2026.03.15.5
 
 - Publish to npm as `tailscale-mcp`, add `.npmignore`, `bin` entry, expanded keywords (#12)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itunified/mcp-tailscale",
-  "version": "2026.3.14",
+  "version": "2026.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@itunified/mcp-tailscale",
-      "version": "2026.3.14",
+      "version": "2026.3.16",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tailscale-mcp",
-  "version": "2026.3.15",
+  "mcpName": "io.github.itunified-io/tailscale",
+  "version": "2026.3.16",
   "description": "Secure MCP access for private infrastructure over Tailscale — 48 tools for devices, DNS, ACL, keys, users, webhooks, posture, and tailnet management via Tailscale API v2",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.itunified-io/tailscale",
+  "title": "Tailscale MCP Server",
+  "description": "Secure MCP access for private infrastructure over Tailscale — 48 tools across 9 domains",
+  "version": "2026.3.16",
+  "repository": {
+    "url": "https://github.com/itunified-io/mcp-tailscale",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "tailscale-mcp",
+      "version": "2026.3.16",
+      "runtimeHint": "npx",
+      "runtimeArguments": [],
+      "packageArguments": [],
+      "environmentVariables": [
+        {
+          "name": "TAILSCALE_API_KEY",
+          "description": "Tailscale API key",
+          "required": false
+        },
+        {
+          "name": "TAILSCALE_OAUTH_CLIENT_ID",
+          "description": "OAuth client ID (alternative to API key)",
+          "required": false
+        },
+        {
+          "name": "TAILSCALE_OAUTH_CLIENT_SECRET",
+          "description": "OAuth client secret",
+          "required": false
+        },
+        {
+          "name": "TAILSCALE_TAILNET",
+          "description": "Tailnet name",
+          "required": true
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Register `io.github.itunified-io/tailscale` on official MCP Registry (registry.modelcontextprotocol.io)
- Add `server.json` metadata file for MCP registry publishing
- Add `mcpName` field to `package.json` for registry validation
- Bump version to `2026.3.16`, published `tailscale-mcp@2026.3.16` to npm
- Add `.mcpregistry_*` to `.gitignore` (token files)

Closes #12

## Test plan
- [x] `tailscale-mcp@2026.3.16` live on npm: `npm view tailscale-mcp version`
- [x] `io.github.itunified-io/tailscale` published on MCP Registry
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)