### PR TITLE
chore: add ADR-0024 reference to .gitignore and CLAUDE.md (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,5 @@ vite.config.ts.timestamp-*
 # Superpowers plugin working artifacts (ADR-0021)
 docs/superpowers/
 
-# MCP Registry tokens
+# MCP Registry tokens (ADR-0024)
 .mcpregistry_*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.2
+
+- Add ADR-0024 reference to `.gitignore` and MCP Registry Tokens entry to CLAUDE.md security section (#35)
+
 ## v2026.03.16.1
 
 - Register on official MCP Registry as `io.github.itunified-io/tailscale` (#12)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ docs/
 - **Error handling**: No credential leaks in error messages (Bearer token never appears in logs or errors)
 - **Credentials**: Never hardcoded, never logged, never in git
 - **Secret Redaction — MANDATORY**: When using `grep`, `cat`, `sed`, `awk`, shell scripts, or any tool that reads/displays file contents containing secrets (`.env`, credentials, API keys, tokens, passwords), **ALWAYS redact the secret values** in output. Never display raw secret values in terminal output, logs, conversation context, or commit messages.
+- **MCP Registry Tokens**: `.mcpregistry_*` files are gitignored (ADR-0024). Never commit registry auth tokens.
 - **Public Repo Documentation Policy — MANDATORY**: This is a **public repository**. All documentation, code examples, test data, and commit messages MUST use only generic placeholders:
   - Tailnet names: `your-tailnet-name`, `example.com`
   - Device IDs: `123456789`


### PR DESCRIPTION
## Summary
- Add ADR-0024 reference to MCP registry token gitignore comment
- Add MCP Registry Tokens entry to CLAUDE.md security section

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)