### PR TITLE
feat: Plugin API — createServer() factory for enterprise extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.16.3
+
+- **Plugin API: extract `createServer()` factory for enterprise extensibility** (#37)
+  - Add `src/types.ts` with `ToolHandler`, `ToolMiddleware`, and `ToolResult` types
+  - Add `src/server.ts` with `createServer()` factory supporting optional middleware
+  - Refactor `src/index.ts` to use `createServer()` internally (zero behavior change)
+  - Add `exports` map to `package.json` for subpath imports (`/server`, `/types`, `/client/*`, `/utils/*`, `/transport`)
+  - Add design doc `docs/plans/003-plugin-api.md`
+  - 199 unit tests (was 188)
+
 ## v2026.03.16.2
 
 - Add ADR-0024 reference to `.gitignore` and MCP Registry Tokens entry to CLAUDE.md security section (#35)

--- a/docs/plans/003-plugin-api.md
+++ b/docs/plans/003-plugin-api.md
@@ -1,0 +1,146 @@
+# 003 — Plugin API: createServer() Factory
+
+## Status
+
+Draft
+
+## Date
+
+2026-03-16
+
+## GitHub Issue
+
+[#37](https://github.com/itunified-io/mcp-tailscale/issues/37)
+
+## Problem
+
+`src/index.ts` is monolithic — server creation, tool registration, transport setup, and process lifecycle are all module-scoped side effects with zero exports. The enterprise edition (`mcp-tailscale-enterprise`) needs to import the server, tool definitions, and tool handlers to wrap them with middleware (audit, RBAC, SSO, policy) without forking the core.
+
+## Solution
+
+Extract a `createServer()` factory function and add typed middleware support.
+
+### New Files
+
+#### `src/types.ts`
+
+Export shared types for tool handling and middleware:
+
+```typescript
+import { ITailscaleClient } from "./client/types.js";
+
+export type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+export type ToolHandler = (
+  name: string,
+  args: Record<string, unknown>,
+  client: ITailscaleClient,
+) => Promise<ToolResult>;
+
+export type ToolMiddleware = (
+  name: string,
+  args: Record<string, unknown>,
+  client: ITailscaleClient,
+  next: ToolHandler,
+) => Promise<ToolResult>;
+```
+
+#### `src/server.ts`
+
+Extract server creation logic from `index.ts`:
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { ITailscaleClient } from "./client/types.js";
+import { ToolHandler, ToolMiddleware, ToolResult } from "./types.js";
+
+export interface CreateServerOptions {
+  middleware?: ToolMiddleware;
+  name?: string;
+  version?: string;
+}
+
+export interface CreateServerResult {
+  server: Server;
+  client: ITailscaleClient;
+  allToolDefinitions: Tool[];
+  toolHandlers: Map<string, ToolHandler>;
+}
+
+export function createServer(options?: CreateServerOptions): CreateServerResult;
+```
+
+The function:
+1. Creates `ITailscaleClient` via `createClientFromEnv()`
+2. Assembles `allToolDefinitions` array (48 tools)
+3. Builds `toolHandlers` Map
+4. Creates MCP `Server` with name/version from options or defaults
+5. Registers `ListTools` handler (returns all tool definitions)
+6. Registers `CallTools` handler — if middleware provided, wraps handler: `middleware(name, args, client, originalHandler)`, otherwise calls handler directly
+7. Returns `{ server, client, allToolDefinitions, toolHandlers }`
+
+### Refactored `src/index.ts`
+
+Becomes a thin CLI entry point:
+
+```typescript
+import { createServer } from "./server.js";
+import { validateTransportConfig, createAuthMiddleware } from "./transport.js";
+// ... transport imports
+
+const { server } = createServer();
+
+async function main() {
+  // ... same transport logic as before
+}
+
+main().catch(/* ... */);
+```
+
+No behavior change for existing users.
+
+### `package.json` Exports Map
+
+```json
+"exports": {
+  ".": "./dist/index.js",
+  "./server": "./dist/server.js",
+  "./types": "./dist/types.js",
+  "./client/*": "./dist/client/*.js",
+  "./utils/*": "./dist/utils/*.js",
+  "./transport": "./dist/transport.js"
+}
+```
+
+## Prerequisites
+
+- None (self-contained refactor)
+
+## Execution Steps
+
+1. Create `src/types.ts` with `ToolHandler`, `ToolMiddleware`, `ToolResult` types
+2. Create `src/server.ts` with `createServer()` factory
+3. Refactor `src/index.ts` to use `createServer()` internally
+4. Add `exports` map to `package.json`
+5. Run `npm test` — all existing tests must pass
+6. Run `npm run build` — must succeed
+7. Verify `npx tailscale-mcp` still works (backward compat)
+8. Update CHANGELOG.md
+9. Publish to npm
+
+## Rollback
+
+Revert the 3 changed files (`index.ts`, `package.json`) and 2 new files (`types.ts`, `server.ts`). No data migration, no API changes.
+
+## Verification
+
+- `npm test` passes (all 188 existing tests)
+- `npm run build` succeeds
+- `npx tailscale-mcp` works unchanged
+- Enterprise can import: `import { createServer } from "tailscale-mcp/server"`
+- Enterprise can import: `import { ToolMiddleware } from "tailscale-mcp/types"`
+- Middleware is called when provided to `createServer({ middleware })`

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "description": "Secure MCP access for private infrastructure over Tailscale — 48 tools for devices, DNS, ACL, keys, users, webhooks, posture, and tailnet management via Tailscale API v2",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./server": "./dist/server.js",
+    "./types": "./dist/types.js",
+    "./client/*": "./dist/client/*.js",
+    "./utils/*": "./dist/utils/*.js",
+    "./transport": "./dist/transport.js"
+  },
   "bin": {
     "mcp-tailscale": "dist/index.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,76 +1,15 @@
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+/**
+ * CLI entry point for mcp-tailscale.
+ * Uses createServer() factory and connects the appropriate transport.
+ */
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
 import { validateTransportConfig, createAuthMiddleware } from "./transport.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import type { ITailscaleClient } from "./client/types.js";
-import { createClientFromEnv } from "./client/client-factory.js";
-import { deviceToolDefinitions, handleDeviceTool } from "./tools/devices.js";
-import { dnsToolDefinitions, handleDnsTool } from "./tools/dns.js";
-import { aclToolDefinitions, handleAclTool } from "./tools/acl.js";
-import { keyToolDefinitions, handleKeyTool } from "./tools/keys.js";
-import { tailnetToolDefinitions, handleTailnetTool } from "./tools/tailnet.js";
-import { diagnosticsToolDefinitions, handleDiagnosticsTool } from "./tools/diagnostics.js";
-import { userToolDefinitions, handleUserTool } from "./tools/users.js";
-import { webhookToolDefinitions, handleWebhookTool } from "./tools/webhooks.js";
-import { postureToolDefinitions, handlePostureTool } from "./tools/posture.js";
+import { createServer } from "./server.js";
 
-const allToolDefinitions: Tool[] = ([
-  ...deviceToolDefinitions,
-  ...dnsToolDefinitions,
-  ...aclToolDefinitions,
-  ...keyToolDefinitions,
-  ...tailnetToolDefinitions,
-  ...diagnosticsToolDefinitions,
-  ...userToolDefinitions,
-  ...webhookToolDefinitions,
-  ...postureToolDefinitions,
-] as unknown) as Tool[];
-
-const toolHandlers = new Map<
-  string,
-  (name: string, args: Record<string, unknown>, client: ITailscaleClient) => Promise<{ content: Array<{ type: "text"; text: string }> }>
->();
-
-for (const def of deviceToolDefinitions) toolHandlers.set(def.name, handleDeviceTool);
-for (const def of dnsToolDefinitions) toolHandlers.set(def.name, handleDnsTool);
-for (const def of aclToolDefinitions) toolHandlers.set(def.name, handleAclTool);
-for (const def of keyToolDefinitions) toolHandlers.set(def.name, handleKeyTool);
-for (const def of tailnetToolDefinitions) toolHandlers.set(def.name, handleTailnetTool);
-for (const def of diagnosticsToolDefinitions) toolHandlers.set(def.name, handleDiagnosticsTool);
-for (const def of userToolDefinitions) toolHandlers.set(def.name, handleUserTool);
-for (const def of webhookToolDefinitions) toolHandlers.set(def.name, handleWebhookTool);
-for (const def of postureToolDefinitions) toolHandlers.set(def.name, handlePostureTool);
-
-const server = new Server(
-  { name: "mcp-tailscale", version: "2026.3.14" },
-  { capabilities: { tools: {} } },
-);
-
-const client = createClientFromEnv();
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: allToolDefinitions,
-}));
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  const handler = toolHandlers.get(name);
-
-  if (!handler) {
-    return {
-      content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
-      isError: true,
-    };
-  }
-
-  return handler(name, (args ?? {}) as Record<string, unknown>, client);
-});
+const { server } = createServer();
 
 async function main() {
   const config = validateTransportConfig(process.env as Record<string, string | undefined>);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,163 @@
+/**
+ * Server factory for mcp-tailscale.
+ * Creates an MCP server with all Tailscale tools registered.
+ * Supports optional middleware for enterprise extensions (audit, RBAC, etc.).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { ITailscaleClient } from "./client/types.js";
+import { createClientFromEnv } from "./client/client-factory.js";
+import type { ToolHandler, ToolMiddleware } from "./types.js";
+
+import { deviceToolDefinitions, handleDeviceTool } from "./tools/devices.js";
+import { dnsToolDefinitions, handleDnsTool } from "./tools/dns.js";
+import { aclToolDefinitions, handleAclTool } from "./tools/acl.js";
+import { keyToolDefinitions, handleKeyTool } from "./tools/keys.js";
+import {
+  tailnetToolDefinitions,
+  handleTailnetTool,
+} from "./tools/tailnet.js";
+import {
+  diagnosticsToolDefinitions,
+  handleDiagnosticsTool,
+} from "./tools/diagnostics.js";
+import { userToolDefinitions, handleUserTool } from "./tools/users.js";
+import {
+  webhookToolDefinitions,
+  handleWebhookTool,
+} from "./tools/webhooks.js";
+import {
+  postureToolDefinitions,
+  handlePostureTool,
+} from "./tools/posture.js";
+
+/**
+ * Options for creating an MCP Tailscale server.
+ */
+export interface CreateServerOptions {
+  /** Optional middleware to intercept all tool calls (for audit, RBAC, etc.) */
+  middleware?: ToolMiddleware;
+  /** Server name (default: "mcp-tailscale") */
+  name?: string;
+  /** Server version (default: "2026.3.16") */
+  version?: string;
+}
+
+/**
+ * Result from createServer().
+ */
+export interface CreateServerResult {
+  /** The MCP server instance, ready to connect a transport */
+  server: Server;
+  /** The Tailscale API client */
+  client: ITailscaleClient;
+  /** All 48 tool definitions */
+  allToolDefinitions: Tool[];
+  /** Map of tool name → handler function */
+  toolHandlers: Map<string, ToolHandler>;
+}
+
+/**
+ * Create an MCP server with all Tailscale tools registered.
+ *
+ * @example
+ * // Basic usage (identical to running `npx tailscale-mcp`)
+ * const { server } = createServer();
+ *
+ * @example
+ * // With enterprise middleware
+ * const { server } = createServer({
+ *   middleware: async (name, args, client, next) => {
+ *     console.log(`Tool called: ${name}`);
+ *     return next(name, args, client);
+ *   },
+ * });
+ */
+export function createServer(
+  options?: CreateServerOptions,
+): CreateServerResult {
+  const {
+    middleware,
+    name = "mcp-tailscale",
+    version = "2026.3.16",
+  } = options ?? {};
+
+  // Assemble all tool definitions
+  const allToolDefinitions: Tool[] = [
+    ...deviceToolDefinitions,
+    ...dnsToolDefinitions,
+    ...aclToolDefinitions,
+    ...keyToolDefinitions,
+    ...tailnetToolDefinitions,
+    ...diagnosticsToolDefinitions,
+    ...userToolDefinitions,
+    ...webhookToolDefinitions,
+    ...postureToolDefinitions,
+  ] as unknown as Tool[];
+
+  // Build tool handler map
+  const toolHandlers = new Map<string, ToolHandler>();
+
+  for (const def of deviceToolDefinitions)
+    toolHandlers.set(def.name, handleDeviceTool);
+  for (const def of dnsToolDefinitions)
+    toolHandlers.set(def.name, handleDnsTool);
+  for (const def of aclToolDefinitions)
+    toolHandlers.set(def.name, handleAclTool);
+  for (const def of keyToolDefinitions)
+    toolHandlers.set(def.name, handleKeyTool);
+  for (const def of tailnetToolDefinitions)
+    toolHandlers.set(def.name, handleTailnetTool);
+  for (const def of diagnosticsToolDefinitions)
+    toolHandlers.set(def.name, handleDiagnosticsTool);
+  for (const def of userToolDefinitions)
+    toolHandlers.set(def.name, handleUserTool);
+  for (const def of webhookToolDefinitions)
+    toolHandlers.set(def.name, handleWebhookTool);
+  for (const def of postureToolDefinitions)
+    toolHandlers.set(def.name, handlePostureTool);
+
+  // Create Tailscale API client
+  const client = createClientFromEnv();
+
+  // Create MCP server
+  const server = new Server(
+    { name, version },
+    { capabilities: { tools: {} } },
+  );
+
+  // Register ListTools handler
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: allToolDefinitions,
+  }));
+
+  // Register CallTools handler (with optional middleware)
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name: toolName, arguments: args } = request.params;
+    const handler = toolHandlers.get(toolName);
+
+    if (!handler) {
+      return {
+        content: [
+          { type: "text" as const, text: `Unknown tool: ${toolName}` },
+        ],
+        isError: true,
+      };
+    }
+
+    const typedArgs = (args ?? {}) as Record<string, unknown>;
+
+    if (middleware) {
+      return middleware(toolName, typedArgs, client, handler);
+    }
+
+    return handler(toolName, typedArgs, client);
+  });
+
+  return { server, client, allToolDefinitions, toolHandlers };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared types for MCP tool handling and middleware.
+ * Used by the core server and enterprise extensions.
+ */
+
+import type { ITailscaleClient } from "./client/types.js";
+
+/**
+ * Result returned by a tool handler.
+ */
+export type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+/**
+ * Handler function for a single MCP tool.
+ * Receives the tool name, validated arguments, and Tailscale client.
+ */
+export type ToolHandler = (
+  name: string,
+  args: Record<string, unknown>,
+  client: ITailscaleClient,
+) => Promise<ToolResult>;
+
+/**
+ * Middleware that intercepts tool calls before/after execution.
+ * Call `next(name, args, client)` to continue to the actual handler.
+ * Enterprise uses this for audit logging, RBAC, policy enforcement, etc.
+ */
+export type ToolMiddleware = (
+  name: string,
+  args: Record<string, unknown>,
+  client: ITailscaleClient,
+  next: ToolHandler,
+) => Promise<ToolResult>;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the client factory before importing server
+vi.mock("../src/client/client-factory.js", () => ({
+  createClientFromEnv: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    deleteVoid: vi.fn(),
+    postVoid: vi.fn(),
+  })),
+}));
+
+import { createServer } from "../src/server.js";
+import type { ToolHandler, ToolMiddleware, ToolResult } from "../src/types.js";
+
+describe("createServer", () => {
+  it("returns server, client, tool definitions, and handlers", () => {
+    const result = createServer();
+
+    expect(result.server).toBeDefined();
+    expect(result.client).toBeDefined();
+    expect(result.allToolDefinitions).toBeDefined();
+    expect(result.toolHandlers).toBeDefined();
+  });
+
+  it("registers all 48 tool definitions", () => {
+    const { allToolDefinitions } = createServer();
+    expect(allToolDefinitions.length).toBe(48);
+  });
+
+  it("registers handlers for all 48 tools", () => {
+    const { toolHandlers } = createServer();
+    expect(toolHandlers.size).toBe(48);
+  });
+
+  it("all tool definitions have name and description", () => {
+    const { allToolDefinitions } = createServer();
+    for (const tool of allToolDefinitions) {
+      expect(tool.name).toBeTruthy();
+      expect(tool.description).toBeTruthy();
+    }
+  });
+
+  it("every tool definition has a corresponding handler", () => {
+    const { allToolDefinitions, toolHandlers } = createServer();
+    for (const tool of allToolDefinitions) {
+      expect(toolHandlers.has(tool.name)).toBe(true);
+    }
+  });
+
+  it("accepts custom server name and version", () => {
+    const { server } = createServer({
+      name: "custom-server",
+      version: "1.0.0",
+    });
+    expect(server).toBeDefined();
+  });
+
+  it("uses default name and version when not specified", () => {
+    const { server } = createServer();
+    expect(server).toBeDefined();
+  });
+
+  it("accepts middleware option", () => {
+    const middleware: ToolMiddleware = async (name, args, client, next) => {
+      return next(name, args, client);
+    };
+
+    const { server } = createServer({ middleware });
+    expect(server).toBeDefined();
+  });
+});
+
+describe("ToolMiddleware type", () => {
+  it("middleware receives name, args, client, and next", async () => {
+    const mockNext: ToolHandler = async (name, args, client) => ({
+      content: [{ type: "text", text: `result for ${name}` }],
+    });
+
+    const middleware: ToolMiddleware = async (name, args, client, next) => {
+      expect(name).toBe("test_tool");
+      expect(args).toEqual({ key: "value" });
+      expect(client).toBeDefined();
+      expect(next).toBe(mockNext);
+      return next(name, args, client);
+    };
+
+    const mockClient = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+      deleteVoid: vi.fn(),
+      postVoid: vi.fn(),
+    };
+
+    // Verify middleware can be called with correct signature
+    await expect(
+      middleware("test_tool", { key: "value" }, mockClient as any, mockNext),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "result for test_tool" }],
+    });
+  });
+
+  it("middleware can modify result", async () => {
+    const mockNext: ToolHandler = async () => ({
+      content: [{ type: "text", text: "original" }],
+    });
+
+    const middleware: ToolMiddleware = async (name, args, client, next) => {
+      const result = await next(name, args, client);
+      return {
+        content: [
+          { type: "text" as const, text: `wrapped: ${result.content[0].text}` },
+        ],
+      };
+    };
+
+    const result = await middleware(
+      "tool",
+      {},
+      {} as any,
+      mockNext,
+    );
+
+    expect(result.content[0].text).toBe("wrapped: original");
+  });
+
+  it("middleware can short-circuit (deny access)", async () => {
+    const mockNext: ToolHandler = vi.fn(async () => ({
+      content: [{ type: "text", text: "should not reach" }],
+    }));
+
+    const denyMiddleware: ToolMiddleware = async (name, args, client, next) => {
+      return {
+        content: [{ type: "text" as const, text: "Access denied" }],
+        isError: true,
+      };
+    };
+
+    const result = await denyMiddleware("tool", {}, {} as any, mockNext);
+
+    expect(result.content[0].text).toBe("Access denied");
+    expect(result.isError).toBe(true);
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #37

- Extract `createServer()` factory from monolithic `src/index.ts` to enable enterprise middleware integration
- Add `ToolHandler`, `ToolMiddleware`, `ToolResult` types in new `src/types.ts`
- Add `exports` map to `package.json` for subpath imports (`/server`, `/types`, `/client/*`, `/utils/*`, `/transport`)
- Refactor `src/index.ts` to use `createServer()` internally — zero behavior change for existing users
- Design doc: `docs/plans/003-plugin-api.md`

## Enterprise Usage

```typescript
import { createServer } from "tailscale-mcp/server";
import type { ToolMiddleware } from "tailscale-mcp/types";

const auditMiddleware: ToolMiddleware = async (name, args, client, next) => {
  console.log(`Tool called: ${name}`);
  const result = await next(name, args, client);
  console.log(`Tool completed: ${name}`);
  return result;
};

const { server } = createServer({ middleware: auditMiddleware });
```

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — 199 tests pass (188 existing + 11 new)
- [ ] `npx tailscale-mcp` still works (backward compat)
- [ ] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)