### PR TITLE
Fix DERP map, log streaming, and tailnet lock 404 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 This project uses [Calendar Versioning](https://calver.org/) (`YYYY.MM.DD.TS`).
 
 
+## v2026.03.17.1
+
+- **Fix DERP map, log streaming, and tailnet lock 404 handling** (#42)
+  - Fix `tailscale_derp_map` to read from ACL policy's `derpMap` field instead of non-existent standalone endpoint
+  - Add `tailscale_derp_map_set` tool — sets custom DERP regions (IDs 900-999) by patching the ACL policy
+  - Handle 404 gracefully for `tailscale_log_stream_get` — returns "not configured" instead of error
+  - Handle 404 gracefully for `tailscale_tailnet_lock_status` — returns "not initialized" with CLI setup instructions
+  - Tool count: 48 → 49
+  - Tests: 199 → 205
+
 ## v2026.03.16.4
 
 - **Add pre-publish security scan** (#39)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -96,7 +96,8 @@ Authentication: `Authorization: Bearer <api-key>` or OAuth client credentials
 | `tailscale_api_verify` | GET | `/tailnet/{tailnet}/devices` (connectivity check) |
 | `tailscale_log_stream_get` | GET | `/tailnet/{tailnet}/logging/{logType}/stream` |
 | `tailscale_log_stream_set` | PUT | `/tailnet/{tailnet}/logging/{logType}/stream` |
-| `tailscale_derp_map` | GET | `/tailnet/{tailnet}/derp-map` |
+| `tailscale_derp_map` | GET | `/tailnet/{tailnet}/acl` (extracts `derpMap` field) |
+| `tailscale_derp_map_set` | GET+POST | `/tailnet/{tailnet}/acl` (reads ACL, patches `derpMap`, writes back) |
 
 ## Notes
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ export interface CreateServerResult {
   server: Server;
   /** The Tailscale API client */
   client: ITailscaleClient;
-  /** All 48 tool definitions */
+  /** All 49 tool definitions */
   allToolDefinitions: Tool[];
   /** Map of tool name → handler function */
   toolHandlers: Map<string, ToolHandler>;

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ITailscaleClient } from "../client/types.js";
-import type { DeviceListResponse, DerpMap, LogStreamConfig } from "../client/types.js";
+import type { DeviceListResponse, DerpMap, LogStreamConfig, AclPolicy } from "../client/types.js";
+import { TailscaleApiError } from "../utils/errors.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -28,6 +29,35 @@ const LogStreamSetSchema = z.object({
 });
 
 const DerpMapSchema = z.object({});
+
+const DerpMapSetSchema = z.object({
+  regions: z.record(
+    z.string(),
+    z.object({
+      regionId: z.number().int().positive(),
+      regionCode: z.string().min(1),
+      regionName: z.string().min(1),
+      avoid: z.boolean().optional(),
+      nodes: z.array(
+        z.object({
+          name: z.string().min(1),
+          regionId: z.number().int().positive(),
+          hostName: z.string().min(1),
+          certName: z.string().optional(),
+          ipv4: z.string().optional(),
+          ipv6: z.string().optional(),
+          stunPort: z.number().int().optional(),
+          stunOnly: z.boolean().optional(),
+          derpPort: z.number().int().optional(),
+        }),
+      ),
+    }),
+  ),
+  omitDefaultRegions: z.boolean().optional(),
+  confirm: z.literal(true, {
+    errorMap: () => ({ message: "confirm must be true to update the DERP map" }),
+  }),
+});
 
 // ---------------------------------------------------------------------------
 // Tool definitions (for ListTools)
@@ -99,10 +129,62 @@ export const diagnosticsToolDefinitions = [
   {
     name: "tailscale_derp_map",
     description:
-      "Get the DERP relay map for the tailnet. Shows all DERP regions and their relay nodes used for traffic routing.",
+      "Get the custom DERP relay map from the tailnet's ACL policy. Returns the derpMap field from the ACL, or a 'not configured' message if no custom DERP map exists.",
     inputSchema: {
       type: "object" as const,
       properties: {},
+    },
+  },
+  {
+    name: "tailscale_derp_map_set",
+    description:
+      "Set or update the custom DERP relay map in the tailnet's ACL policy. Requires confirm: true. Custom DERP regions use IDs 900-999. Set omitDefaultRegions: true to replace Tailscale's default relays entirely.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        regions: {
+          type: "object",
+          description: "Map of region ID (string) to region config. Custom regions should use IDs 900-999.",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              regionId: { type: "number", description: "Region ID (900-999 for custom)" },
+              regionCode: { type: "string", description: "Short region code (e.g., 'mydc')" },
+              regionName: { type: "string", description: "Human-readable region name" },
+              avoid: { type: "boolean", description: "If true, avoid using this region" },
+              nodes: {
+                type: "array",
+                description: "DERP nodes in this region",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string", description: "Node name" },
+                    regionId: { type: "number", description: "Must match parent region" },
+                    hostName: { type: "string", description: "DERP server hostname" },
+                    certName: { type: "string", description: "TLS cert name if different from hostName" },
+                    ipv4: { type: "string", description: "IPv4 address" },
+                    ipv6: { type: "string", description: "IPv6 address" },
+                    stunPort: { type: "number", description: "STUN port (default 3478)" },
+                    stunOnly: { type: "boolean", description: "If true, only use for STUN" },
+                    derpPort: { type: "number", description: "DERP port (default 443)" },
+                  },
+                  required: ["name", "regionId", "hostName"],
+                },
+              },
+            },
+            required: ["regionId", "regionCode", "regionName", "nodes"],
+          },
+        },
+        omitDefaultRegions: {
+          type: "boolean",
+          description: "If true, omit Tailscale's default DERP regions and use only custom ones",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Must be true to confirm the DERP map update",
+        },
+      },
+      required: ["regions", "confirm"],
     },
   },
 ];
@@ -180,10 +262,22 @@ export async function handleDiagnosticsTool(
 
       case "tailscale_log_stream_get": {
         const parsed = LogStreamGetSchema.parse(args);
-        const result = await client.get<LogStreamConfig>(
-          `/tailnet/${client.tailnet}/logging/${parsed.logType}/stream`,
-        );
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+          const result = await client.get<LogStreamConfig>(
+            `/tailnet/${client.tailnet}/logging/${parsed.logType}/stream`,
+          );
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (err: unknown) {
+          if (err instanceof TailscaleApiError && err.status === 404 ||
+              err instanceof Error && err.message.includes("404")) {
+            return { content: [{ type: "text", text: JSON.stringify({
+              configured: false,
+              logType: parsed.logType,
+              message: `No log streaming configured for '${parsed.logType}' logs. Configure via the Tailscale admin console (https://login.tailscale.com/admin/logs) or use tailscale_log_stream_set to set a streaming destination.`,
+            }, null, 2) }] };
+          }
+          throw err;
+        }
       }
 
       case "tailscale_log_stream_set": {
@@ -200,10 +294,44 @@ export async function handleDiagnosticsTool(
 
       case "tailscale_derp_map": {
         DerpMapSchema.parse(args);
-        const result = await client.get<DerpMap>(
-          `/tailnet/${client.tailnet}/derp-map`,
+        // DERP map is managed through the ACL policy's derpMap field
+        const acl = await client.get<AclPolicy & { derpMap?: DerpMap }>(
+          `/tailnet/${client.tailnet}/acl`,
         );
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        if (acl.derpMap) {
+          return { content: [{ type: "text", text: JSON.stringify({
+            source: "acl-policy",
+            derpMap: acl.derpMap,
+          }, null, 2) }] };
+        }
+        return { content: [{ type: "text", text: JSON.stringify({
+          configured: false,
+          message: "No custom DERP map configured in ACL policy. The tailnet uses Tailscale's default DERP relay regions. To add custom DERP servers, use tailscale_derp_map_set with regions using IDs 900-999.",
+        }, null, 2) }] };
+      }
+
+      case "tailscale_derp_map_set": {
+        const parsed = DerpMapSetSchema.parse(args);
+        // Read current ACL, patch derpMap, write back
+        const currentAcl = await client.get<Record<string, unknown>>(
+          `/tailnet/${client.tailnet}/acl`,
+        );
+        const derpMap: Record<string, unknown> = {
+          Regions: parsed.regions,
+        };
+        if (parsed.omitDefaultRegions !== undefined) {
+          derpMap["OmitDefaultRegions"] = parsed.omitDefaultRegions;
+        }
+        const updatedAcl = { ...currentAcl, derpMap };
+        const result = await client.post<AclPolicy>(
+          `/tailnet/${client.tailnet}/acl`,
+          updatedAcl,
+        );
+        return { content: [{ type: "text", text: JSON.stringify({
+          message: "DERP map updated in ACL policy",
+          derpMap,
+          aclUpdated: true,
+        }, null, 2) }] };
       }
 
       default:

--- a/src/tools/tailnet.ts
+++ b/src/tools/tailnet.ts
@@ -5,6 +5,7 @@ import type {
   TailnetContacts,
   TailnetLockStatus,
 } from "../client/types.js";
+import { TailscaleApiError } from "../utils/errors.js";
 
 // ---------------------------------------------------------------------------
 // Zod schemas for input validation
@@ -213,10 +214,22 @@ export async function handleTailnetTool(
 
       case "tailscale_tailnet_lock_status": {
         TailnetLockStatusSchema.parse(args);
-        const result = await client.get<TailnetLockStatus>(
-          `/tailnet/${client.tailnet}/lock/status`,
-        );
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        try {
+          const result = await client.get<TailnetLockStatus>(
+            `/tailnet/${client.tailnet}/lock/status`,
+          );
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } catch (err: unknown) {
+          if (err instanceof TailscaleApiError && err.status === 404 ||
+              err instanceof Error && err.message.includes("404")) {
+            return { content: [{ type: "text", text: JSON.stringify({
+              enabled: false,
+              initialized: false,
+              message: "Tailnet Lock is not initialized. Tailnet Lock requires CLI setup — it cannot be enabled via API. Steps: (1) Run 'tailscale lock init' on a trusted device, (2) Sign existing nodes with 'tailscale lock sign', (3) Status will then be available via this tool. See https://tailscale.com/kb/1226/tailnet-lock for details.",
+            }, null, 2) }] };
+          }
+          throw err;
+        }
       }
 
       case "tailscale_tailnet_settings_update": {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -26,14 +26,14 @@ describe("createServer", () => {
     expect(result.toolHandlers).toBeDefined();
   });
 
-  it("registers all 48 tool definitions", () => {
+  it("registers all 49 tool definitions", () => {
     const { allToolDefinitions } = createServer();
-    expect(allToolDefinitions.length).toBe(48);
+    expect(allToolDefinitions.length).toBe(49);
   });
 
-  it("registers handlers for all 48 tools", () => {
+  it("registers handlers for all 49 tools", () => {
     const { toolHandlers } = createServer();
-    expect(toolHandlers.size).toBe(48);
+    expect(toolHandlers.size).toBe(49);
   });
 
   it("all tool definitions have name and description", () => {

--- a/tests/tools/diagnostics.test.ts
+++ b/tests/tools/diagnostics.test.ts
@@ -23,8 +23,8 @@ function mockClient(overrides: Partial<ITailscaleClient> = {}): TailscaleClient 
 // ---------------------------------------------------------------------------
 
 describe("Diagnostics Tool Definitions", () => {
-  it("exports 5 tool definitions", () => {
-    expect(diagnosticsToolDefinitions).toHaveLength(5);
+  it("exports 6 tool definitions", () => {
+    expect(diagnosticsToolDefinitions).toHaveLength(6);
   });
 
   it("all tools have tailscale_ prefix", () => {
@@ -163,6 +163,20 @@ describe("handleDiagnosticsTool", () => {
 
       expect(result.content[0].text).toContain("Error executing tailscale_log_stream_get");
     });
+
+    it("returns not-configured message on 404", async () => {
+      const error = new Error("404 page not found");
+      const client = mockClient({ get: vi.fn().mockRejectedValue(error) });
+
+      const result = await handleDiagnosticsTool("tailscale_log_stream_get", {
+        logType: "configuration",
+      }, client);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.configured).toBe(false);
+      expect(parsed.logType).toBe("configuration");
+      expect(parsed.message).toContain("No log streaming configured");
+    });
   });
 
   describe("tailscale_log_stream_set", () => {
@@ -212,31 +226,117 @@ describe("handleDiagnosticsTool", () => {
   });
 
   describe("tailscale_derp_map", () => {
-    it("gets the DERP map", async () => {
-      const mockDerpMap = {
-        regions: {
-          "1": {
-            regionId: 1,
-            regionCode: "nyc",
-            regionName: "New York City",
-            nodes: [{ name: "1a", regionId: 1, hostName: "derp1.tailscale.com", ipv4: "1.2.3.4", ipv6: "::1" }],
+    it("returns custom DERP map from ACL policy", async () => {
+      const mockAcl = {
+        acls: [],
+        derpMap: {
+          Regions: {
+            "900": {
+              regionId: 900,
+              regionCode: "mydc",
+              regionName: "My Data Center",
+              nodes: [{ name: "900a", regionId: 900, hostName: "derp.example.com", ipv4: "1.2.3.4", ipv6: "::1" }],
+            },
           },
         },
       };
-      const client = mockClient({ get: vi.fn().mockResolvedValue(mockDerpMap) });
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockAcl) });
 
       const result = await handleDiagnosticsTool("tailscale_derp_map", {}, client);
 
-      expect(result.content[0].text).toContain("nyc");
-      expect(client.get).toHaveBeenCalledWith(`/tailnet/${TAILNET}/derp-map`);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.source).toBe("acl-policy");
+      expect(parsed.derpMap).toBeDefined();
+      expect(client.get).toHaveBeenCalledWith(`/tailnet/${TAILNET}/acl`);
+    });
+
+    it("returns not-configured message when no custom DERP map in ACL", async () => {
+      const mockAcl = { acls: [], groups: {} };
+      const client = mockClient({ get: vi.fn().mockResolvedValue(mockAcl) });
+
+      const result = await handleDiagnosticsTool("tailscale_derp_map", {}, client);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.configured).toBe(false);
+      expect(parsed.message).toContain("No custom DERP map");
     });
 
     it("handles API errors gracefully", async () => {
-      const client = mockClient({ get: vi.fn().mockRejectedValue(new Error("Not found")) });
+      const client = mockClient({ get: vi.fn().mockRejectedValue(new Error("Unauthorized")) });
 
       const result = await handleDiagnosticsTool("tailscale_derp_map", {}, client);
 
       expect(result.content[0].text).toContain("Error executing tailscale_derp_map");
+    });
+  });
+
+  describe("tailscale_derp_map_set", () => {
+    it("updates DERP map in ACL policy when confirmed", async () => {
+      const currentAcl = { acls: [], groups: {} };
+      const updatedAcl = { acls: [], groups: {}, derpMap: {} };
+      const client = mockClient({
+        get: vi.fn().mockResolvedValue(currentAcl),
+        post: vi.fn().mockResolvedValue(updatedAcl),
+      });
+
+      const result = await handleDiagnosticsTool("tailscale_derp_map_set", {
+        regions: {
+          "900": {
+            regionId: 900,
+            regionCode: "mydc",
+            regionName: "My Data Center",
+            nodes: [{ name: "900a", regionId: 900, hostName: "derp.example.com" }],
+          },
+        },
+        confirm: true,
+      }, client);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.aclUpdated).toBe(true);
+      expect(parsed.message).toContain("DERP map updated");
+      expect(client.get).toHaveBeenCalledWith(`/tailnet/${TAILNET}/acl`);
+      expect(client.post).toHaveBeenCalledWith(
+        `/tailnet/${TAILNET}/acl`,
+        expect.objectContaining({ derpMap: expect.any(Object) }),
+      );
+    });
+
+    it("rejects without confirm: true", async () => {
+      const client = mockClient();
+
+      const result = await handleDiagnosticsTool("tailscale_derp_map_set", {
+        regions: { "900": { regionId: 900, regionCode: "x", regionName: "X", nodes: [] } },
+        confirm: false,
+      }, client);
+
+      expect(result.content[0].text).toContain("Error executing tailscale_derp_map_set");
+    });
+
+    it("supports omitDefaultRegions", async () => {
+      const client = mockClient({
+        get: vi.fn().mockResolvedValue({ acls: [] }),
+        post: vi.fn().mockResolvedValue({}),
+      });
+
+      await handleDiagnosticsTool("tailscale_derp_map_set", {
+        regions: {
+          "900": {
+            regionId: 900,
+            regionCode: "mydc",
+            regionName: "My DC",
+            nodes: [{ name: "900a", regionId: 900, hostName: "derp.example.com" }],
+          },
+        },
+        omitDefaultRegions: true,
+        confirm: true,
+      }, client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/tailnet/${TAILNET}/acl`,
+        expect.objectContaining({
+          derpMap: expect.objectContaining({ OmitDefaultRegions: true }),
+        }),
+      );
     });
   });
 

--- a/tests/tools/tailnet.test.ts
+++ b/tests/tools/tailnet.test.ts
@@ -179,8 +179,20 @@ describe("handleTailnetTool", () => {
       expect(client.get).toHaveBeenCalledWith(`/tailnet/${TAILNET}/lock/status`);
     });
 
-    it("handles API errors gracefully", async () => {
-      const client = mockClient({ get: vi.fn().mockRejectedValue(new Error("Not found")) });
+    it("returns not-initialized message on 404", async () => {
+      const error = new Error("404 Not Found");
+      const client = mockClient({ get: vi.fn().mockRejectedValue(error) });
+
+      const result = await handleTailnetTool("tailscale_tailnet_lock_status", {}, client);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.enabled).toBe(false);
+      expect(parsed.initialized).toBe(false);
+      expect(parsed.message).toContain("not initialized");
+    });
+
+    it("handles non-404 API errors gracefully", async () => {
+      const client = mockClient({ get: vi.fn().mockRejectedValue(new Error("Unauthorized")) });
 
       const result = await handleTailnetTool("tailscale_tailnet_lock_status", {}, client);
 


### PR DESCRIPTION
## Summary

- Fix `tailscale_derp_map` to read from ACL policy's `derpMap` field (the standalone `/derp-map` endpoint returns 404 when no custom map exists)
- Add `tailscale_derp_map_set` tool — patches ACL policy with custom DERP regions (IDs 900-999)
- Handle 404 gracefully for `tailscale_log_stream_get` — returns "not configured" instead of error
- Handle 404 gracefully for `tailscale_tailnet_lock_status` — returns "not initialized" with CLI setup instructions (Tailnet Lock can only be enabled via `tailscale lock init` CLI command)

## Test plan

- [x] `npm run build` — zero TypeScript errors
- [x] `npm test` — 205 tests pass (was 199)
- [ ] Live test: `tailscale_derp_map` returns "not configured" (no custom DERP)
- [ ] Live test: `tailscale_log_stream_get` returns "not configured"
- [ ] Live test: `tailscale_tailnet_lock_status` returns "not initialized"

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)